### PR TITLE
Update remote datasets metadata

### DIFF
--- a/data_remote.json
+++ b/data_remote.json
@@ -21,34 +21,6 @@
         "description": "A variant of the 'rugby' example dataset. The Six Nations Championship is a yearly rugby competition between Italy, Ireland, Scotland, England, France and Wales. Fifteen games are played each year, representing all combinations of the six teams.\n\nThis example uses and includes results from 2014 - 2017, comprising 60 total games. It models latent parameters for each team's attack and defense, with each team having different values depending on them being home or away team.\n\nSee https://github.com/arviz-devs/arviz_example_data/blob/main/code/rugby_field/rugby_field.ipynb for the whole model specification."
     },
     {
-        "name": "regression1d",
-        "filename": "regression1d.nc",
-        "url": "http://ndownloader.figshare.com/files/16254899",
-        "checksum": "909e8ffe344e196dad2730b1542881ab5729cb0977dd20ba645a532ffa427278",
-        "description": "A synthetic one dimensional linear regression dataset with latent slope, intercept, and noise (\"eps\"). One hundred data points, fit with PyMC3.\n\nTrue slope and intercept are included as deterministic variables."
-    },
-    {
-        "name": "regression10d",
-        "filename": "regression10d.nc",
-        "url": "http://ndownloader.figshare.com/files/16255736",
-        "checksum": "c6716ec7e19926ad2a52d6ae4c1d1dd5ddb747e204c0d811757c8e93fcf9f970",
-        "description": "A synthetic multi-dimensional (10 dimensions) linear regression dataset with latent weights (\"w\"), intercept, and noise (\"eps\"). Five hundred data points, fit with PyMC3.\n\nTrue weights and intercept are included as deterministic variables."
-    },
-    {
-        "name": "classification1d",
-        "filename": "classification1d.nc",
-        "url": "http://ndownloader.figshare.com/files/16256678",
-        "checksum": "1cf3806e72c14001f6864bb69d89747dcc09dd55bcbca50aba04e9939daee5a0",
-        "description": "A synthetic one dimensional logistic regression dataset with latent slope and intercept, passed into a Bernoulli random variable. One hundred data points, fit with PyMC3.\n\nTrue slope and intercept are included as deterministic variables."
-    },
-    {
-        "name": "classification10d",
-        "filename": "classification10d.nc",
-        "url": "http://ndownloader.figshare.com/files/16256681",
-        "checksum": "16c9a45e1e6e0519d573cafc4d266d761ba347e62b6f6a79030aaa8e2fde1367",
-        "description": "A synthetic multi dimensional (10 dimensions) logistic regression dataset with latent weights (\"w\") and intercept, passed into a Bernoulli random variable. Five hundred data points, fit with PyMC3.\n\nTrue weights and intercept are included as deterministic variables."
-    },
-    {
         "name": "glycan_torsion_angles",
         "filename": "glycan_torsion_angles.nc",
         "url": "http://ndownloader.figshare.com/files/22882652",

--- a/data_remote.json
+++ b/data_remote.json
@@ -54,5 +54,61 @@
         "url": "http://ndownloader.figshare.com/files/22882652",
         "checksum": "4622621fe7a1d3075c18c4c34af8cc57c59eabbb3501b20c6e2d9c6c4737034c",
         "description": "Torsion angles phi and psi are critical for determining the three dimensional structure of bio-molecules. Combinations of phi and psi torsion angles that produce clashes between atoms in the bio-molecule result in high energy, unlikely structures.\n\nThis model uses a Von Mises distribution to propose torsion angles for the structure of a glycan molecule (pdb id: 2LIQ), and a Potential to estimate the proposed structure's energy. Said Potential is bound by Boltzman's law."
+    },
+    {
+        "name": "crabs_poisson",
+        "filename": "crabs_poisson.nc",
+        "url": "https://figshare.com/ndownloader/files/53391239",
+        "checksum": "991f2abff5e16ba67f5741899a5c55b183690ef6be7b1c36c663ee9e0e31d736",
+        "description": "Horseshoe crabs arrive at the beach in pairs for their spawning ritual. Solitary males gather around the nesting couples and vying to fertilize the eggs. These individuals, known as satellite males, often congregate near certain nesting pairs while disregarding others.\n\nWe use Bambi to create a hurdle-negative binomial model for the number of male satellites as a function of the carapace width and color of the female.\n\nFor details see https://doi.org/10.1111/j.1439-0310.1996.tb01099.x and https://bap.com.ar."
+    },
+    {
+        "name": "crabs_hurdle_nb",
+        "filename": "crabs_hurdle_nb.nc",
+        "url": "https://figshare.com/ndownloader/files/53391224",
+        "checksum": "c7e2d0dde938be90444ad6e8da39136b20ee9c58ab0172ed238dac0e28fa1731",
+        "description": "Horseshoe crabs arrive at the beach in pairs for their spawning ritual. Solitary males gather around the nesting couples and vying to fertilize the eggs. These individuals, known as satellite males, often congregate near certain nesting pairs while disregarding others.\n\nWe use Bambi to create a hurdle-negative binomial model for the number of male satellites as a function of the carapace width and color of the female.\n\nFor details see https://doi.org/10.1111/j.1439-0310.1996.tb01099.x and https://bap.com.ar."
+    },
+    {
+        "name": "sbc",
+        "filename": "sbc.nc",
+        "url": "https://figshare.com/ndownloader/files/52915271",
+        "checksum": "f7b4931906748832b8fc5898feac1ea15fb0896355917e4238f57b48cb7d1f8e",
+        "description": "Simulated Based Calibration with the eight-school dataset and PyMC with NUTS sampler. 100 very short simulations were carried-out"
+    },
+    {
+        "name": "anes",
+        "filename": "anes.nc",
+        "url": "http://figshare.com/ndownloader/files/53391248",
+        "checksum": "dcb1170e1748f748f04aae4b8c1761c2a0f08556ebb1f99c1a76623f333236ed",
+        "description": "Logistic regression model for American National Election Studies (ANES) data. The model aims to predict voter intention for Clinton based on party identification and its interaction with age."
+    },
+    {
+        "name": "periwinkles",
+        "filename": "periwinkles.nc",
+        "url": "http://figshare.com/ndownloader/files/53391296",
+        "checksum": "a3d1cf3b72d5d616c2ecaa7936c6bc6698fd7c4958f2601c632917eaa7803ccd",
+        "description": "31 periwinkles (a kind of sea snail) were removed from it original place and released down shore. A VonMises likelihood is used to model the direction of motion as function of the distance travelled by the periwinkles after being release."
+    },
+    {
+        "name": "censored_cats",
+        "filename": "censored_cats.nc",
+        "url": "http://figshare.com/ndownloader/files/58114255",
+        "checksum": "02432a7972a5f599645b6c952e0f236d5192fdd72d77f381060155aca1872b4d",
+        "description": "Simple model of the survival curve for cat adoptions from an animal shelter in Austin, Texas. The dataset comes from the City of Austin Open Data Portal for more details of the model you can check bambi's documentation"
+    },
+    {
+        "name": "roaches_nb",
+        "filename": "roaches_nb.nc",
+        "url": "http://figshare.com/ndownloader/files/59961428",
+        "checksum": "d23cdcac455e664026aecded63448ec00d8644c1e0ea850b8ef4632c0b3c72e2",
+        "description": "The roaches data example comes from Chapter 8.3 of of Gelman and Hill (2007)."
+    },
+    {
+        "name": "roaches_zinb",
+        "filename": "roaches_zinb.nc",
+        "url": "http://figshare.com/ndownloader/files/59961890",
+        "checksum": "49dc422da36ffd8c1ba58a0888a178cf229444b527459af2a88376eb151b28bc",
+        "description": "The roaches data example comes from Chapter 8.3 of of Gelman and Hill (2007)."
     }
 ]


### PR DESCRIPTION
This includes new remote datasets which were only added to arviz-base and removes datasets
we were not using (that also have limited use due to being regression related yet have no
constant data with the covariates used).
