### PR TITLE
use http in urls to align with downstream assumptions

### DIFF
--- a/data_remote.json
+++ b/data_remote.json
@@ -30,21 +30,21 @@
     {
         "name": "crabs_poisson",
         "filename": "crabs_poisson.nc",
-        "url": "https://figshare.com/ndownloader/files/53391239",
+        "url": "http://figshare.com/ndownloader/files/53391239",
         "checksum": "991f2abff5e16ba67f5741899a5c55b183690ef6be7b1c36c663ee9e0e31d736",
         "description": "Horseshoe crabs arrive at the beach in pairs for their spawning ritual. Solitary males gather around the nesting couples and vying to fertilize the eggs. These individuals, known as satellite males, often congregate near certain nesting pairs while disregarding others.\n\nWe use Bambi to create a hurdle-negative binomial model for the number of male satellites as a function of the carapace width and color of the female.\n\nFor details see https://doi.org/10.1111/j.1439-0310.1996.tb01099.x and https://bap.com.ar."
     },
     {
         "name": "crabs_hurdle_nb",
         "filename": "crabs_hurdle_nb.nc",
-        "url": "https://figshare.com/ndownloader/files/53391224",
+        "url": "http://figshare.com/ndownloader/files/53391224",
         "checksum": "c7e2d0dde938be90444ad6e8da39136b20ee9c58ab0172ed238dac0e28fa1731",
         "description": "Horseshoe crabs arrive at the beach in pairs for their spawning ritual. Solitary males gather around the nesting couples and vying to fertilize the eggs. These individuals, known as satellite males, often congregate near certain nesting pairs while disregarding others.\n\nWe use Bambi to create a hurdle-negative binomial model for the number of male satellites as a function of the carapace width and color of the female.\n\nFor details see https://doi.org/10.1111/j.1439-0310.1996.tb01099.x and https://bap.com.ar."
     },
     {
         "name": "sbc",
         "filename": "sbc.nc",
-        "url": "https://figshare.com/ndownloader/files/52915271",
+        "url": "http://figshare.com/ndownloader/files/52915271",
         "checksum": "f7b4931906748832b8fc5898feac1ea15fb0896355917e4238f57b48cb7d1f8e",
         "description": "Simulated Based Calibration with the eight-school dataset and PyMC with NUTS sampler. 100 very short simulations were carried-out"
     },


### PR DESCRIPTION
Downstream code assumes urls have http and replaces that with https depending on rcparams.
Having https in the urls would break the downstream assumptions.
