### PR TITLE
Standardize figshare URLs

### DIFF
--- a/data_remote.json
+++ b/data_remote.json
@@ -2,84 +2,84 @@
     {
         "name": "radon",
         "filename": "radon_hierarchical.nc",
-        "url": "http://ndownloader.figshare.com/files/24067472",
+        "url": "https://ndownloader.figshare.com/files/24067472",
         "checksum": "a9b2b4adf1bf9c5728e5bdc97107e69c4fc8d8b7d213e9147233b57be8b4587b",
         "description": "Radon is a radioactive gas that enters homes through contact points with the ground. It is a carcinogen that is the primary cause of lung cancer in non-smokers. Radon levels vary greatly from household to household.\n\nThis example uses an EPA study of radon levels in houses in Minnesota to construct a model with a hierarchy over households within a county. The model includes estimates (gamma) for contextual effects of the uranium per household.\n\nSee Gelman and Hill (2006) for details on the example, or https://docs.pymc.io/notebooks/multilevel_modeling.html by Chris Fonnesbeck for details on this implementation."
     },
     {
         "name": "rugby",
         "filename": "rugby.nc",
-        "url": "http://ndownloader.figshare.com/files/44916469",
+        "url": "https://ndownloader.figshare.com/files/44916469",
         "checksum": "f4a5e699a8a4cc93f722eb97929dd7c4895c59a2183f05309f5082f3f81eb228",
         "description": "The Six Nations Championship is a yearly rugby competition between Italy, Ireland, Scotland, England, France and Wales. Fifteen games are played each year, representing all combinations of the six teams.\n\nThis example uses and includes results from 2014 - 2017, comprising 60 total games. It models latent parameters for each team's attack and defense, as well as a global parameter for home team advantage.\n\nSee https://github.com/arviz-devs/arviz_example_data/blob/main/code/rugby/rugby.ipynb for the whole model specification."
     },
     {
         "name": "rugby_field",
         "filename": "rugby_field.nc",
-        "url": "http://ndownloader.figshare.com/files/44667112",
+        "url": "https://ndownloader.figshare.com/files/44667112",
         "checksum": "53a99da7ac40d82cd01bb0b089263b9633ee016f975700e941b4c6ea289a1fb0",
         "description": "A variant of the 'rugby' example dataset. The Six Nations Championship is a yearly rugby competition between Italy, Ireland, Scotland, England, France and Wales. Fifteen games are played each year, representing all combinations of the six teams.\n\nThis example uses and includes results from 2014 - 2017, comprising 60 total games. It models latent parameters for each team's attack and defense, with each team having different values depending on them being home or away team.\n\nSee https://github.com/arviz-devs/arviz_example_data/blob/main/code/rugby_field/rugby_field.ipynb for the whole model specification."
     },
     {
         "name": "glycan_torsion_angles",
         "filename": "glycan_torsion_angles.nc",
-        "url": "http://ndownloader.figshare.com/files/22882652",
+        "url": "https://ndownloader.figshare.com/files/22882652",
         "checksum": "4622621fe7a1d3075c18c4c34af8cc57c59eabbb3501b20c6e2d9c6c4737034c",
         "description": "Torsion angles phi and psi are critical for determining the three dimensional structure of bio-molecules. Combinations of phi and psi torsion angles that produce clashes between atoms in the bio-molecule result in high energy, unlikely structures.\n\nThis model uses a Von Mises distribution to propose torsion angles for the structure of a glycan molecule (pdb id: 2LIQ), and a Potential to estimate the proposed structure's energy. Said Potential is bound by Boltzman's law."
     },
     {
         "name": "crabs_poisson",
         "filename": "crabs_poisson.nc",
-        "url": "http://ndownloader.figshare.com/files/53391239",
+        "url": "https://ndownloader.figshare.com/files/53391239",
         "checksum": "991f2abff5e16ba67f5741899a5c55b183690ef6be7b1c36c663ee9e0e31d736",
         "description": "Horseshoe crabs arrive at the beach in pairs for their spawning ritual. Solitary males gather around the nesting couples and vying to fertilize the eggs. These individuals, known as satellite males, often congregate near certain nesting pairs while disregarding others.\n\nWe use Bambi to create a hurdle-negative binomial model for the number of male satellites as a function of the carapace width and color of the female.\n\nFor details see https://doi.org/10.1111/j.1439-0310.1996.tb01099.x and https://bap.com.ar."
     },
     {
         "name": "crabs_hurdle_nb",
         "filename": "crabs_hurdle_nb.nc",
-        "url": "http://ndownloader.figshare.com/files/53391224",
+        "url": "https://ndownloader.figshare.com/files/53391224",
         "checksum": "c7e2d0dde938be90444ad6e8da39136b20ee9c58ab0172ed238dac0e28fa1731",
         "description": "Horseshoe crabs arrive at the beach in pairs for their spawning ritual. Solitary males gather around the nesting couples and vying to fertilize the eggs. These individuals, known as satellite males, often congregate near certain nesting pairs while disregarding others.\n\nWe use Bambi to create a hurdle-negative binomial model for the number of male satellites as a function of the carapace width and color of the female.\n\nFor details see https://doi.org/10.1111/j.1439-0310.1996.tb01099.x and https://bap.com.ar."
     },
     {
         "name": "sbc",
         "filename": "sbc.nc",
-        "url": "http://ndownloader.figshare.com/files/52915271",
+        "url": "https://ndownloader.figshare.com/files/52915271",
         "checksum": "f7b4931906748832b8fc5898feac1ea15fb0896355917e4238f57b48cb7d1f8e",
         "description": "Simulated Based Calibration with the eight-school dataset and PyMC with NUTS sampler. 100 very short simulations were carried-out"
     },
     {
         "name": "anes",
         "filename": "anes.nc",
-        "url": "http://ndownloader.figshare.com/files/53391248",
+        "url": "https://ndownloader.figshare.com/files/53391248",
         "checksum": "dcb1170e1748f748f04aae4b8c1761c2a0f08556ebb1f99c1a76623f333236ed",
         "description": "Logistic regression model for American National Election Studies (ANES) data. The model aims to predict voter intention for Clinton based on party identification and its interaction with age."
     },
     {
         "name": "periwinkles",
         "filename": "periwinkles.nc",
-        "url": "http://ndownloader.figshare.com/files/53391296",
+        "url": "https://ndownloader.figshare.com/files/53391296",
         "checksum": "a3d1cf3b72d5d616c2ecaa7936c6bc6698fd7c4958f2601c632917eaa7803ccd",
         "description": "31 periwinkles (a kind of sea snail) were removed from it original place and released down shore. A VonMises likelihood is used to model the direction of motion as function of the distance travelled by the periwinkles after being release."
     },
     {
         "name": "censored_cats",
         "filename": "censored_cats.nc",
-        "url": "http://ndownloader.figshare.com/files/58114255",
+        "url": "https://ndownloader.figshare.com/files/58114255",
         "checksum": "02432a7972a5f599645b6c952e0f236d5192fdd72d77f381060155aca1872b4d",
         "description": "Simple model of the survival curve for cat adoptions from an animal shelter in Austin, Texas. The dataset comes from the City of Austin Open Data Portal for more details of the model you can check bambi's documentation"
     },
     {
         "name": "roaches_nb",
         "filename": "roaches_nb.nc",
-        "url": "http://ndownloader.figshare.com/files/59961428",
+        "url": "https://ndownloader.figshare.com/files/59961428",
         "checksum": "d23cdcac455e664026aecded63448ec00d8644c1e0ea850b8ef4632c0b3c72e2",
         "description": "The roaches data example comes from Chapter 8.3 of of Gelman and Hill (2007)."
     },
     {
         "name": "roaches_zinb",
         "filename": "roaches_zinb.nc",
-        "url": "http://ndownloader.figshare.com/files/59961890",
+        "url": "https://ndownloader.figshare.com/files/59961890",
         "checksum": "49dc422da36ffd8c1ba58a0888a178cf229444b527459af2a88376eb151b28bc",
         "description": "The roaches data example comes from Chapter 8.3 of of Gelman and Hill (2007)."
     }

--- a/data_remote.json
+++ b/data_remote.json
@@ -9,14 +9,14 @@
     {
         "name": "rugby",
         "filename": "rugby.nc",
-        "url": "http://figshare.com/ndownloader/files/44916469",
+        "url": "http://ndownloader.figshare.com/files/44916469",
         "checksum": "f4a5e699a8a4cc93f722eb97929dd7c4895c59a2183f05309f5082f3f81eb228",
         "description": "The Six Nations Championship is a yearly rugby competition between Italy, Ireland, Scotland, England, France and Wales. Fifteen games are played each year, representing all combinations of the six teams.\n\nThis example uses and includes results from 2014 - 2017, comprising 60 total games. It models latent parameters for each team's attack and defense, as well as a global parameter for home team advantage.\n\nSee https://github.com/arviz-devs/arviz_example_data/blob/main/code/rugby/rugby.ipynb for the whole model specification."
     },
     {
         "name": "rugby_field",
         "filename": "rugby_field.nc",
-        "url": "http://figshare.com/ndownloader/files/44667112",
+        "url": "http://ndownloader.figshare.com/files/44667112",
         "checksum": "53a99da7ac40d82cd01bb0b089263b9633ee016f975700e941b4c6ea289a1fb0",
         "description": "A variant of the 'rugby' example dataset. The Six Nations Championship is a yearly rugby competition between Italy, Ireland, Scotland, England, France and Wales. Fifteen games are played each year, representing all combinations of the six teams.\n\nThis example uses and includes results from 2014 - 2017, comprising 60 total games. It models latent parameters for each team's attack and defense, with each team having different values depending on them being home or away team.\n\nSee https://github.com/arviz-devs/arviz_example_data/blob/main/code/rugby_field/rugby_field.ipynb for the whole model specification."
     },
@@ -30,56 +30,56 @@
     {
         "name": "crabs_poisson",
         "filename": "crabs_poisson.nc",
-        "url": "http://figshare.com/ndownloader/files/53391239",
+        "url": "http://ndownloader.figshare.com/files/53391239",
         "checksum": "991f2abff5e16ba67f5741899a5c55b183690ef6be7b1c36c663ee9e0e31d736",
         "description": "Horseshoe crabs arrive at the beach in pairs for their spawning ritual. Solitary males gather around the nesting couples and vying to fertilize the eggs. These individuals, known as satellite males, often congregate near certain nesting pairs while disregarding others.\n\nWe use Bambi to create a hurdle-negative binomial model for the number of male satellites as a function of the carapace width and color of the female.\n\nFor details see https://doi.org/10.1111/j.1439-0310.1996.tb01099.x and https://bap.com.ar."
     },
     {
         "name": "crabs_hurdle_nb",
         "filename": "crabs_hurdle_nb.nc",
-        "url": "http://figshare.com/ndownloader/files/53391224",
+        "url": "http://ndownloader.figshare.com/files/53391224",
         "checksum": "c7e2d0dde938be90444ad6e8da39136b20ee9c58ab0172ed238dac0e28fa1731",
         "description": "Horseshoe crabs arrive at the beach in pairs for their spawning ritual. Solitary males gather around the nesting couples and vying to fertilize the eggs. These individuals, known as satellite males, often congregate near certain nesting pairs while disregarding others.\n\nWe use Bambi to create a hurdle-negative binomial model for the number of male satellites as a function of the carapace width and color of the female.\n\nFor details see https://doi.org/10.1111/j.1439-0310.1996.tb01099.x and https://bap.com.ar."
     },
     {
         "name": "sbc",
         "filename": "sbc.nc",
-        "url": "http://figshare.com/ndownloader/files/52915271",
+        "url": "http://ndownloader.figshare.com/files/52915271",
         "checksum": "f7b4931906748832b8fc5898feac1ea15fb0896355917e4238f57b48cb7d1f8e",
         "description": "Simulated Based Calibration with the eight-school dataset and PyMC with NUTS sampler. 100 very short simulations were carried-out"
     },
     {
         "name": "anes",
         "filename": "anes.nc",
-        "url": "http://figshare.com/ndownloader/files/53391248",
+        "url": "http://ndownloader.figshare.com/files/53391248",
         "checksum": "dcb1170e1748f748f04aae4b8c1761c2a0f08556ebb1f99c1a76623f333236ed",
         "description": "Logistic regression model for American National Election Studies (ANES) data. The model aims to predict voter intention for Clinton based on party identification and its interaction with age."
     },
     {
         "name": "periwinkles",
         "filename": "periwinkles.nc",
-        "url": "http://figshare.com/ndownloader/files/53391296",
+        "url": "http://ndownloader.figshare.com/files/53391296",
         "checksum": "a3d1cf3b72d5d616c2ecaa7936c6bc6698fd7c4958f2601c632917eaa7803ccd",
         "description": "31 periwinkles (a kind of sea snail) were removed from it original place and released down shore. A VonMises likelihood is used to model the direction of motion as function of the distance travelled by the periwinkles after being release."
     },
     {
         "name": "censored_cats",
         "filename": "censored_cats.nc",
-        "url": "http://figshare.com/ndownloader/files/58114255",
+        "url": "http://ndownloader.figshare.com/files/58114255",
         "checksum": "02432a7972a5f599645b6c952e0f236d5192fdd72d77f381060155aca1872b4d",
         "description": "Simple model of the survival curve for cat adoptions from an animal shelter in Austin, Texas. The dataset comes from the City of Austin Open Data Portal for more details of the model you can check bambi's documentation"
     },
     {
         "name": "roaches_nb",
         "filename": "roaches_nb.nc",
-        "url": "http://figshare.com/ndownloader/files/59961428",
+        "url": "http://ndownloader.figshare.com/files/59961428",
         "checksum": "d23cdcac455e664026aecded63448ec00d8644c1e0ea850b8ef4632c0b3c72e2",
         "description": "The roaches data example comes from Chapter 8.3 of of Gelman and Hill (2007)."
     },
     {
         "name": "roaches_zinb",
         "filename": "roaches_zinb.nc",
-        "url": "http://figshare.com/ndownloader/files/59961890",
+        "url": "http://ndownloader.figshare.com/files/59961890",
         "checksum": "49dc422da36ffd8c1ba58a0888a178cf229444b527459af2a88376eb151b28bc",
         "description": "The roaches data example comes from Chapter 8.3 of of Gelman and Hill (2007)."
     }


### PR DESCRIPTION
I was having trouble downloading the files for the new remote datasets from Julia because they use a different URL format than the older remote datasets. From the examples in https://info.figshare.com/user-guide/how-to-use-the-figshare-api/#download-files, it seems that to download a file *in the browser* one uses a URL of the form `https://figshare.com/ndownloader/files/<id>` , but to download a file *outside of the browser*, one uses `https://ndownloader.figshare.com/files/<id>` (also works in the browser).

This PR changes all the remote datasets to use the `https://figshare.com/ndownloader/files/<id>` format, including changing the `http://` prefixes to `https://`.